### PR TITLE
reCaptcha API v. 2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,6 +11,12 @@ browser view, so these two packages can be swapped for each other relatively
 simply.  Use collective.captcha if you need to not be dependent on an external
 service; use collective.recaptcha for a slightly better user experience.
 
+Upgrade
+-------
+
+Upgrading to collective.recaptcha 2.* (reCaptcha API V2) you need double check your keys
+because global Keys are not supported in the V2 API, so you need to create a new key
+if you wish to use the V2 API.
 
 Installation and Configuration
 ------------------------------
@@ -20,7 +26,7 @@ this package at the same time as collective.captcha, because the '@@captcha'
 browser view registration will conflict.)
 
 Before the service will work, you must obtain a public and private key from
-http://recaptcha.net, and configure them at http://path/to/site/@@recaptcha-settings
+https://developers.google.com/recaptcha/, and configure them at http://path/to/site/@@recaptcha-settings
 
 You can use plone.app.registry in your profile to provide your configuration::
 

--- a/collective/recaptcha/view.py
+++ b/collective/recaptcha/view.py
@@ -4,7 +4,8 @@ from zope.annotation import factory
 from zope import schema
 from zope.publisher.interfaces.browser import IBrowserRequest
 from Products.Five import BrowserView
-from recaptcha.client.captcha import displayhtml, submit
+# from recaptcha.client.captcha import displayhtml, submit
+from norecaptcha.captcha import displayhtml, submit
 from collective.recaptcha.settings import getRecaptchaSettings
 
 
@@ -37,20 +38,12 @@ class RecaptchaView(BrowserView):
             lang = portal_state.language()[:2]
         else:
             lang = 'en'
-        options = """
-        <script type="text/javascript">
-        var RecaptchaOptions = {
-            lang: '%s'
-        };
-        </script>
-        """ % lang
 
         if not self.settings.public_key:
             raise ValueError, 'No recaptcha public key configured. \
                 Go to path/to/site/@@recaptcha-settings to configure.'
-        use_ssl = self.request['SERVER_URL'].startswith('https://')
-        error = IRecaptchaInfo(self.request).error
-        return options + displayhtml(self.settings.public_key, use_ssl=use_ssl, error=error)
+        # error = IRecaptchaInfo(self.request).error
+        return displayhtml(self.settings.public_key, language=lang)
 
     def audio_url(self):
         return None
@@ -63,12 +56,11 @@ class RecaptchaView(BrowserView):
         if not self.settings.private_key:
             raise ValueError, 'No recaptcha private key configured. \
                 Go to path/to/site/@@recaptcha-settings to configure.'
-        challenge_field = self.request.get('recaptcha_challenge_field')
-        response_field = self.request.get('recaptcha_response_field')
+        response_field = self.request.get('g-recaptcha-response')
         remote_addr = self.request.get('HTTP_X_FORWARDED_FOR', '').split(',')[0]
         if not remote_addr:
             remote_addr = self.request.get('REMOTE_ADDR')
-        res = submit(challenge_field, response_field, self.settings.private_key, remote_addr)
+        res = submit(response_field, self.settings.private_key, remote_addr)
         if res.error_code:
             info.error = res.error_code
 
@@ -78,3 +70,4 @@ class RecaptchaView(BrowserView):
     @property
     def external(self):
         return True
+

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -1,10 +1,11 @@
 Changelog
 =========
 
-1.1.6 (unreleased)
+2.0.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Google reCaptcha API v.2
+  [mamico]
 
 
 1.1.5 (2014-05-07)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 import os
 
-version = '1.1.6.dev0'
+version = '2.0.0.dev0'
 
 setup(name='collective.recaptcha',
       version=version,
@@ -29,7 +29,8 @@ setup(name='collective.recaptcha',
       zip_safe=False,
       install_requires=[
           'setuptools',
-          'recaptcha-client >= 1.0.6',
+          # 'recaptcha-client >= 1.0.6',
+          'norecaptcha',
           'Plone',
           # -*- Extra requirements: -*-
       ],


### PR DESCRIPTION
support for reCaptcha API v.2 (using https://pypi.python.org/pypi/norecaptcha instead https://pypi.python.org/pypi/recaptcha-client)