### PR TITLE
Fix black-check and lint

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -95,6 +95,9 @@ deps =
     #flake8_strict
     #flake8-quotes
     flake8-polyfill
+    # FIXME: flake8-html needs to be updated, to be compatible with new versions of Jinja2
+    # See: https://github.com/lordmauve/flake8-html/issues/27
+    Jinja2==3.0.3
 
 commands =
     mkdir -p {toxinidir}/reports/flake8

--- a/tox.ini
+++ b/tox.ini
@@ -128,6 +128,8 @@ deps =
     -cconstraints.txt
     # BBB: black 21.12b0 it is the last version with python2 support.
     black[python2]==21.12b0
+    # BBB: click > 8.0.4 causes error on black < 22.3.0.
+    click==8.0.4
 
 commands =
     black --check --diff -v src setup.py


### PR DESCRIPTION
- `click` > 8.0.4 causes error on `black` < 22.3.0:

```
ImportError: cannot import name '_unicodefun' from 'click'
```
See:

https://github.com/psf/black/issues/2964

We can't update the version of `black` now because `black` 21.12b0 it is the last version with python2 support.

- Pinn `Jinja2`==3.0.3 in lint to avoid error in `flake8-html`