### PR TITLE
Removes compatibility with collective.captcha

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 3.0.0 (unreleased)
 ------------------
 
+- Removes compatibility with ``collective.captcha``.
+  [wesleybl]
+
 - No longer reads settings in annotation in portal root.
   [wesleybl]
 

--- a/README.rst
+++ b/README.rst
@@ -4,10 +4,7 @@ collective.recaptcha
 This package provides an integration of the reCAPTCHA service into Zope.
 ReCAPTCHA is a third-party CAPTCHA service provided by Google.
 
-The API is based on collective.captcha and is provided via a "@@captcha"
-browser view, so these two packages can be swapped for each other relatively
-simply.  Use collective.captcha if you need to not be dependent on an external
-service; use collective.recaptcha for a slightly better user experience.
+The API is provided via a "@@captcha" browser view.
 
 Plone users interested in adding ReCAPTCHA in z3c.form forms
 will probably find interesting the package
@@ -52,28 +49,6 @@ You can verify Recaptcha input by testing the return value of::
 
   context.restrictedTraverse('@@captcha').verify()
 
-
-Differences between this package's API and collective.captcha
--------------------------------------------------------------
-
-Because the simplest form of Recaptcha is rendered entirely via a remote call
-to the service, we couldn't implement the ICaptchaView interface from
-collective.captcha exactly as it was defined there.
-Differences include::
-
-  * The image_tag method returns the HTML for the entire CAPTCHA widget,
-    including text entry and audio link, not just the tag for the CAPTCHA
-    image.
-
-  * The audio_url method returns None
-
-  * The verify method does not require the input parameter, as a standard
-    form input name is used and the value can be found in the request.
-
-  * There is an additional method, external, which simply returns True.
-    This is a bit of a hack so that a template requiring captcha can
-    adjust to the different semantics of the @@captcha view in this
-    package as compared to collective.captcha.
 
 Tests
 -----

--- a/src/collective/recaptcha/configure.zcml
+++ b/src/collective/recaptcha/configure.zcml
@@ -31,7 +31,7 @@
       for="*"
       class=".view.RecaptchaView"
       permission="zope.Public"
-      allowed_attributes="image_tag audio_url verify external"
+      allowed_attributes="image_tag verify"
       />
 
   <browser:page

--- a/src/collective/recaptcha/tests/test_view.py
+++ b/src/collective/recaptcha/tests/test_view.py
@@ -28,9 +28,6 @@ class TestView(unittest.TestCase):
     def test_verify(self):
         self.assertFalse(self.view.verify())
 
-    def test_verify_with_input(self):
-        self.assertFalse(self.view.verify(input="input"))
-
     def test_verify_remote_addr(self):
         self.request["REMOTE_ADDR"] = "localhost"
         self.assertFalse(self.view.verify())
@@ -38,9 +35,3 @@ class TestView(unittest.TestCase):
     def test_verify_http_x_forwarded_for(self):
         self.request["HTTP_X_FORWARDED_FOR"] = "localhost1, localhost2"
         self.assertFalse(self.view.verify())
-
-    def test_audio_url(self):
-        self.assertIsNone(self.view.audio_url())
-
-    def test_external(self):
-        self.assertIs(self.view.external, True)

--- a/src/collective/recaptcha/view.py
+++ b/src/collective/recaptcha/view.py
@@ -48,16 +48,7 @@ class RecaptchaView(BrowserView):
             )
         return displayhtml(self.settings.public_key, language=lang)
 
-    def audio_url(self):
-        """Method for compatibility with collective.captcha. See:
-        https://github.com/collective/collective.recaptcha#differences-between-this-packages-api-and-collectivecaptcha
-        """
-        return None
-
-    def verify(self, input=None):  # @ReservedAssignment
-        """The input parameter is for compatibility with collective.captcha. See:
-        https://github.com/collective/collective.recaptcha#differences-between-this-packages-api-and-collectivecaptcha
-        """
+    def verify(self):
         info = IRecaptchaInfo(self.request)
         if info.verified:
             return True
@@ -77,10 +68,3 @@ class RecaptchaView(BrowserView):
 
         info.verified = res.is_valid
         return res.is_valid
-
-    @property
-    def external(self):
-        """Method for compatibility with collective.captcha. See:
-        https://github.com/collective/collective.recaptcha#differences-between-this-packages-api-and-collectivecaptcha
-        """
-        return True


### PR DESCRIPTION
The latest `collective.captcha` release is from [2012](https://github.com/mjpieters/collective.captcha/blob/master/CHANGELOG.txt#L8). So it shouldn't be being used.