### PR TITLE
Fix recaptcha loading in Plone 4 modal

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 2.1.1 (unreleased)
 ------------------
 
+- Fix recaptcha loading in Plone 4 modal.
+  [wesleybl]
+
 - Fixed startup on Python 3 (Plone 5.2).
   The tests are not run yet on 5.2, so compatibility is not confirmed.
   [maurits]

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(
         "norecaptcha",
         "Plone >=4.3",
         "Products.CMFCore",
+        "Products.CMFPlone",
         "setuptools",
         "zope.component",
         "zope.i18nmessageid",

--- a/src/collective/recaptcha/__init__.py
+++ b/src/collective/recaptcha/__init__.py
@@ -1,5 +1,8 @@
 # coding=utf-8
+from Products.CMFPlone.utils import getFSVersionTuple
 from zope.i18nmessageid import MessageFactory
 
 
 RecaptchaMessageFactory = MessageFactory("collective.recaptcha")
+
+PLONE4 = getFSVersionTuple()[0] == 4

--- a/src/collective/recaptcha/tests/test_view.py
+++ b/src/collective/recaptcha/tests/test_view.py
@@ -1,5 +1,6 @@
 # encoding: utf-8
 """Tests of view."""
+from collective.recaptcha import PLONE4
 from collective.recaptcha.settings import IRecaptchaSettings
 from collective.recaptcha.testing import COLLECTIVE_RECAPTCHA_INTEGRATION_TESTING
 from plone.api.content import get_view
@@ -24,6 +25,22 @@ class TestView(unittest.TestCase):
             "https://www.google.com/recaptcha/api.js?hl=en&fallback=False&", image_tag
         )
         self.assertIn('data-sitekey="111"', image_tag)
+
+    def test_image_tag_extra_script_not_in_normal_request(self):
+        image_tag = self.view.image_tag()
+        self.assertNotIn("<script>", image_tag)
+
+    @unittest.skipUnless(PLONE4, "Relevant only for Plone 4")
+    def test_image_tag_extra_script__in_ajax_request_plone4(self):
+        self.request.set("HTTP_X_REQUESTED_WITH", "XMLHttpRequest")
+        image_tag = self.view.image_tag()
+        self.assertIn("<script>", image_tag)
+
+    @unittest.skipIf(PLONE4, "Relevant only for Plone >= 5")
+    def test_image_tag_extra_script__not_in_ajax_request_plone5(self):
+        self.request.set("HTTP_X_REQUESTED_WITH", "XMLHttpRequest")
+        image_tag = self.view.image_tag()
+        self.assertNotIn("<script>", image_tag)
 
     def test_verify(self):
         self.assertFalse(self.view.verify())


### PR DESCRIPTION
The way `plone.app.jquerytools` handles the modal, jquery removes the script tags from the html loaded in the modal. It looks like javascript code inside the script tag is still executed, but the tag itself is removed. As the recaptcha javascript is in the src attribute, it is not executed once the tag is removed.

So we added a javascript that dynamically add the script tag with src from recaptcha, If the request is ajax.

Fixes #33 